### PR TITLE
Created missing new vars in soilhydrology_type

### DIFF
--- a/src/biogeophys/SoilHydrologyType.F90
+++ b/src/biogeophys/SoilHydrologyType.F90
@@ -32,6 +32,9 @@ Module SoilHydrologyType
      real(r8), pointer :: icefrac_col       (:,:)   ! col fraction of ice       
      real(r8), pointer :: h2osfc_thresh_col (:)     ! col level at which h2osfc "percolates"   (time constant)
      real(r8), pointer :: xs_urban_col      (:)     ! col excess soil water above urban ponding limit
+     ! Aman 2024/10/03 - new vars for zbedrock and wtt
+     real(r8), pointer :: zbedrock_col      (:)     ! col bedrock depth
+     real(r8), pointer :: wtt_col           (:)     ! col water table thickness
 
      ! VIC 
      real(r8), pointer :: hkdepth_col       (:)     ! col VIC decay factor (m) (time constant)                    


### PR DESCRIPTION
### Description of changes
Created new history fields for:
- depth to bedrock ZBEDROCK
- water table thickness WTT

### Specific notes

CTSM Issues Fixed: #2 

Are answers expected to change (and if so in what way)? NO

Any User Interface Changes (namelist or namelist defaults changes)?
Include new fincl variables in user_nl_clm 'ZBEDROCK', 'WTT'

Testing performed, if any:
Tested in `alpha-ctsm5.2.mksrf.23_ctsm5.1.dev171` for 40 days. History fields are present in daily and monthly history tapes.
